### PR TITLE
[feat] Create demo web page for send DM

### DIFF
--- a/peer-noti/config/settings.py
+++ b/peer-noti/config/settings.py
@@ -83,7 +83,6 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [BASE_DIR / 'templates'],
-        'DIRS': [],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/peer-noti/slackbot/forms.py
+++ b/peer-noti/slackbot/forms.py
@@ -1,0 +1,6 @@
+from django import forms
+
+
+class UserForm(forms.Form):
+    intra_id = forms.CharField(max_length=100)
+    message = forms.CharField(widget=forms.Textarea)

--- a/peer-noti/slackbot/slack_api.py
+++ b/peer-noti/slackbot/slack_api.py
@@ -19,7 +19,7 @@ class SlackAPI:
                 return member['id']
         raise Http404("id: [" + intra_id + "]에 해당하는 유저가 존재하지 않습니다.")
 
-    def post_message(self, channel_id, name):
+    def post_message(self, channel_id, name, message):
         """
         슬랙 채널에 메세지 보내기
         channel: user id를 넣을 경우 user에게, channel id를 넣을 경우 channel에게 메세지가 전송됨
@@ -27,7 +27,7 @@ class SlackAPI:
         try:
             result = self.client.chat_postMessage(
                 channel=channel_id,
-                text="Hello " + name
+                text= name + "님 안녕하세요! \n" + message
             )
         except SlackApiError as e:
             print(f"Error posting message: {e}")

--- a/peer-noti/slackbot/views.py
+++ b/peer-noti/slackbot/views.py
@@ -1,29 +1,28 @@
-from django.http import HttpResponse
+from django.contrib import messages
 from django.http import Http404
 from .slack_api import SlackAPI
+from django.shortcuts import render, redirect
+from .forms import UserForm
+
 
 def index(request):
-    return HttpResponse("peer-noti slackbot 페이지입니다.<br>"
-                        "dm을 보내려면 [http://127.0.0.1:8000/slackbot/send/dm/]로 이동하세요!")
-
+    return render(request, 'slackbot/index.html')
 
 def send_dm(request):
-    try:
-        intra_id = request.GET.get('id')
-        if intra_id is None:
-            raise Http404("id: Param not found. <br>"
-                          "dm을 보낼 유저의 intra id를 아래 주소의 파라미터로 넣어주세요! <br>"
-                          "http://127.0.0.1:8000/slackbot/send/dm/?id=[intra_id]")
+    if request.method == 'POST':
+        form = UserForm(request.POST)
+        if form.is_valid():
+            try:
+                intra_id = form.cleaned_data['intra_id']
+                message = form.cleaned_data['message']
+                slack = SlackAPI()
+                user_id = slack.get_user_id(intra_id)
+                slack.post_message(user_id, intra_id, message)
+                messages.success(request, "메시지가 성공적으로 전송되었습니다.")
+                return redirect('slackbot:send_dm')
 
-        slack = SlackAPI()
-        user_id = slack.get_user_id(intra_id)
-        slack.post_message(user_id, intra_id)
-
-
-    except Http404 as e:
-        # 요청 매개변수가 없는 경우 예외 처리
-        response = HttpResponse(str(e))
-        response.status_code = 404
-        return response
-
-    return HttpResponse(intra_id + "님께 DM을 전송합니다.")
+            except Http404 as e:
+                messages.error(request, str(e))
+    else:
+        form = UserForm()
+    return render(request, 'slackbot/dm_form.html', {'form': form})

--- a/peer-noti/templates/alert_message.html
+++ b/peer-noti/templates/alert_message.html
@@ -1,0 +1,9 @@
+{% if messages %}
+   {% for message in messages %}
+       {% if message.tags == 'error' %}
+       <div class="alert alert-danger" role="alert">{{ message }}</div>
+       {% else %}
+           <div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %}" role="alert">{{ message }}</div>
+       {% endif %}
+   {% endfor %}
+{% endif %}

--- a/peer-noti/templates/form_errors.html
+++ b/peer-noti/templates/form_errors.html
@@ -1,0 +1,20 @@
+<!-- 필드 오류와 넌필드 오류를 출력한다.-->
+{% if form.errors %}
+<div class="alert alert-danger">
+    {% for field in form %}
+    <!-- 필드 오류 -->
+    {% if field.errors %}
+    <div>
+        <strong>{{ field.label }}</strong>
+        {{ field.errors }}
+    </div>
+    {% endif %}
+    {% endfor %}
+    <!-- 넌필드 오류 -->
+    {% for error in form.non_field_errors %}
+    <div>
+        <strong>{{ error }}</strong>
+    </div>
+    {% endfor %}
+</div>
+{% endif %}

--- a/peer-noti/templates/slackbot/dm_form.html
+++ b/peer-noti/templates/slackbot/dm_form.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container">
+    <h2 class="my-3 border-bottom pb-2">Slack DM 전송</h2>
+    <form method="post">
+        {% csrf_token %}
+        {% include 'form_errors.html' %}
+        {% include 'alert_message.html' %}
+        <div class="mb-3">
+            <label for="intra_id" class="form-label">Intra id</label>
+            <input type="text" class="form-control" name="intra_id" id="intra_id"
+                    value="{{ form.intra_id.value|default_if_none:'' }}">
+        </div>
+        <div class="mb-3">
+            <label for="message" class="form-label">message</label>
+            <textarea class="form-control" name="message" id="message" rows="10">{{ form.message.value|default_if_none:'' }}</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">전송</button>
+    </form>
+</div>
+{% endblock %}

--- a/peer-noti/templates/slackbot/index.html
+++ b/peer-noti/templates/slackbot/index.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container">
+  <h1 class="my-3 border-bottom pb-2">Peer-Noti</h1>
+  <p>DM을 보내려면 <a href="http://127.0.0.1:8000/slackbot/send/dm/">여기</a>로 이동하세요!</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

DM 전송 데모 웹페이지 제작
- id로 받던 intra_id를 입력으로 받도록 수정

## 🧑‍💻 PR 세부 내용

### [feat]

**[ 템플릿 구현 ]**
- `index.html`: 메인 페이지
- `slackbot/send_dm.html`: DM 전송 페이지
- `form_error.html`: 폼 필드 오류 출력 템플릿
- `alert_message.html`: 알림 메시지 출력 템플릿

**[ 폼 추가 ]**
- `slackbot/Forms.py`: `UserForm`이라는 일반 폼 정의
    - `intra_id` / `message`를 저장하는 필드 생성
    - DM 전송 페이지에서 특정 필드에 대한 입력이 없을 시 폼 필드 오류 출력
- `message` 필드에 입력된 내용을 `post_message()` 함수를 통해 매개변수로 전송

### [fix]
- `peer-noti/config/settings.py`: 템플릿 디렉터리 환경변수 오류 수정

## 📸 스크린샷
- 메인 페이지
<img width="300" alt="스크린샷 2023-05-30 오후 10 32 08" src="https://github.com/peer-42seoul/peer-noti/assets/44529556/c9acd17f-1a44-4dcc-8c38-f87457850fd4">

- DM 전송 페이지
<img width="300" alt="스크린샷 2023-05-30 오후 10 32 45" src="https://github.com/peer-42seoul/peer-noti/assets/44529556/bd6e651b-f39d-49c1-bcd2-8c333e44ff0b">

- 입력하지 않은 필드가 있는 경우
<img width="300" alt="스크린샷 2023-05-30 오후 10 33 36" src="https://github.com/peer-42seoul/peer-noti/assets/44529556/cbe0c802-ef47-44f4-a769-e9e6761b57d9">

- 존재하지 않는 intra id가 입력된 경우
<img width="300" alt="스크린샷 2023-05-30 오후 10 33 54" src="https://github.com/peer-42seoul/peer-noti/assets/44529556/b0458460-6960-4324-b7d6-0a9d8d361142">

- 메시지 전송이 성공한 경우
<img width="300" alt="스크린샷 2023-05-30 오후 10 35 27" src="https://github.com/peer-42seoul/peer-noti/assets/44529556/0dea5bbd-1cc3-4c5b-8c99-c2203985700b">
